### PR TITLE
Part 2670

### DIFF
--- a/helper/compression.go
+++ b/helper/compression.go
@@ -1,0 +1,43 @@
+package helper
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"io/ioutil"
+)
+
+/*
+	Expects a string and returns a base64 encoded string of the compressed string.
+	Approximately reduces the size of the string by atleast 90%
+*/
+func CompressString(stringToCompress string) (string, error) {
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+	if _, err := gz.Write([]byte(stringToCompress)); err != nil {
+		return "", err
+	}
+	if err := gz.Flush(); err != nil {
+		return "", err
+	}
+	if err := gz.Close(); err != nil {
+		return "", err
+	}
+
+	return base64.StdEncoding.EncodeToString(b.Bytes()), nil
+}
+
+/*
+	Expects a compressed string and returns the decompressed string.
+*/
+func DecompressString(stringToDecompress string) (string, error) {
+	decodedString, err := base64.StdEncoding.DecodeString(stringToDecompress)
+	if err != nil {
+		return "", err
+	}
+	rdata := bytes.NewReader(decodedString)
+	r, _ := gzip.NewReader(rdata)
+	s, _ := ioutil.ReadAll(r)
+
+	return string(s), nil
+}

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -124,13 +124,6 @@ func (ps *AWSPubSubAdapter) PollMessages(queueURL string, handler func(message *
 			return fmt.Errorf("message corrupted")
 		}
 
-		// Decompress string if message is not corrupted.
-		messageBody, err := helper.DecompressString(*message.Body)
-		if err != nil {
-			return err
-		}
-		message.Body = aws.String(messageBody)
-
 		err = handler(message)
 		if err != nil {
 			return err

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -62,6 +62,7 @@ func (ps *AWSPubSubAdapter) Publish(topicARN string, message interface{}, messag
 	if err != nil {
 		return err
 	}
+	fmt.Println("uncompressed string", string(jsonString))
 
 	// Compress the message body
 	compressedMessageBody, err := helper.CompressString(string(jsonString))


### PR DESCRIPTION
## Summary
By default, publishes compressed data over to SNS. Saves over 90% of size. It is on the consumer to decompress the message before utilising the same. Compression and Decompression functions can be found under helper package within the pubsub library.


### What?
- Added compression by default
- Decompression and Compression functions added in helper package


### Why?
- File size limit of SQS was failing on publishing a few messages


### Testing Scope
- [ ] Compressed message being published to SNS
- [ ] Decompression working as expected under helper package


<!-- ### Documentation links -->
<!-- add link to document in the parenthesis -->
<!-- - [Notion]() -->
<!-- - [Jira]() -->
<!-- - [Zeplin]() -->
<!-- - [InvisionApp]() -->