### PR TITLE
fix String.Array data formatting 

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -259,7 +259,7 @@ func convertToAttributeValue(value interface{}) (*sns.MessageAttributeValue, err
 	case int, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
 		return &sns.MessageAttributeValue{
 			DataType:    aws.String("Number"),
-			StringValue: aws.String(fmt.Sprint(v)),
+			StringValue: aws.String(v.(string)),
 		}, nil
 	case []string:
 		return &sns.MessageAttributeValue{

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -265,7 +265,7 @@ func convertToAttributeValue(value interface{}) (*sns.MessageAttributeValue, err
 	case int, int32, int64, uint, uint8, uint16, uint32, uint64, float32, float64:
 		return &sns.MessageAttributeValue{
 			DataType:    aws.String("Number"),
-			StringValue: aws.String(v.(string)),
+			StringValue: aws.String(fmt.Sprint(v)),
 		}, nil
 	case []string:
 		jsonValue, err := json.Marshal(v)

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -14,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
 	"github.com/google/uuid"
+	"github.com/pkg/errors"
 
 	"github.com/Orange-Health/pubsublib/helper"
 	"github.com/Orange-Health/pubsublib/infrastructure"
@@ -108,7 +108,10 @@ func (ps *AWSPubSubAdapter) Publish(topicARN string, messageGroupId, messageDedu
 	}
 	awsMessageAttributes := map[string]*sns.MessageAttributeValue{}
 	if messageAttributes != nil {
-		awsMessageAttributes, _ = BindAttributes(messageAttributes)
+		awsMessageAttributes, err = BindAttributes(messageAttributes)
+		if err != nil {
+			return errors.Wrap(err, "error binding attributes")
+		}
 	}
 	pubslishMessage := &sns.PublishInput{
 		Message:           aws.String(messageBody), // Ensures to always send compressed message
@@ -240,7 +243,10 @@ func BindAttributes(attributes map[string]interface{}) (map[string]*sns.MessageA
 	boundAttributes := make(map[string]*sns.MessageAttributeValue)
 
 	for key, value := range attributes {
-		attrValue, _ := convertToAttributeValue(value)
+		attrValue, err := convertToAttributeValue(value)
+		if err != nil {
+			return nil, err
+		}
 		boundAttributes[key] = attrValue
 	}
 	return boundAttributes, nil
@@ -262,9 +268,13 @@ func convertToAttributeValue(value interface{}) (*sns.MessageAttributeValue, err
 			StringValue: aws.String(v.(string)),
 		}, nil
 	case []string:
+		jsonValue, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
 		return &sns.MessageAttributeValue{
 			DataType:    aws.String("String.Array"),
-			StringValue: aws.String(strings.Join(v, ",")),
+			StringValue: aws.String(string(jsonValue)),
 		}, nil
 	// Add more cases for other data types as needed
 


### PR DESCRIPTION
## **User description**
## Summary
If a []string{} type is sent in message attributes, convert it to stringified JSON instead of csv. This is done to handle String.Array datatype in SNS accordingly.

### Why?
- Currently, SNS filter fails on message attributes because of the mismatch in String.Array format

### Testing Scope
- [ ] Sanity



___

## **Description**
- Improved error handling in `BindAttributes` function by returning errors instead of ignoring them.
- Fixed the conversion of number types to strings by casting them to `string` instead of using `fmt.Sprint`.
- Changed the way string arrays are converted to message attributes by using JSON marshalling to ensure proper formatting.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws.go</strong><dd><code>Improved AWS SNS Message Attribute Handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

provider/aws/aws.go
<li>Added error handling for attribute binding in AWS SNS message <br>publishing.<br> <li> Fixed conversion of message attributes to the correct AWS SNS format.<br> <li> Changed direct string conversion to JSON marshalling for string <br>arrays.


</details>
    

  </td>
  <td><a href="https://github.com/Orange-Health/pubsublib/pull/19/files#diff-95fde44621b48d924a9ad43138223f86d3012e63c65400f7051b7cad08096052">+15/-5</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table><details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
