### PR TITLE
stale key deletion

### DIFF
--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -1,10 +1,12 @@
 package aws
 
 import (
+	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -68,6 +70,7 @@ When the SNS Topic is FIFO type, messageGroupId and messageDeduplicationId are r
 */
 func (ps *AWSPubSubAdapter) Publish(topicARN string, messageGroupId, messageDeduplicationId string, message interface{}, messageAttributes map[string]interface{}) error {
 	// Check if message is of type map[string]interface{} and then convert all the keys to snake_case
+	ctx := context.Background()
 	switch message.(type) {
 	case map[string]interface{}:
 		message = helper.ConvertBodyToSnakeCase(message.(map[string]interface{}))
@@ -86,9 +89,15 @@ func (ps *AWSPubSubAdapter) Publish(topicARN string, messageGroupId, messageDedu
 		messageAttributes["redis_key"] = redisKey
 
 		// Set the message body in redis db
-		err = ps.redisClient.Set(redisKey, messageBody, 2*60)
+		err = ps.redisClient.Set(redisKey, messageBody, int(10*24*time.Hour))
 		if err != nil {
-			return err
+			// If redis set fails, then we could possibaly cleanup the key after some time using batch deletion.
+			checker := NewKeyChecker(ps.redisClient.Client, 100) //Thats not a good method there could be another method also like using a interface
+			checker.Start(ctx)
+			checker.Add(redisKey) //keys needed here for cleanup
+			checker.Stop()        // Ensure cleanup
+
+			return fmt.Errorf("failed to set Redis key: %w", err)
 		}
 
 		messageBody = "body is stored in redis under key PUBSUB:" + redisKey

--- a/provider/aws/keychecker.go
+++ b/provider/aws/keychecker.go
@@ -1,0 +1,76 @@
+package aws
+
+import (
+	"context"
+	"log"
+	"sync"
+
+	"github.com/go-redis/redis/v8"
+)
+
+// example picked up from github redis example to delete keys efficiently without TTL
+type KeyChecker struct {
+	redisClient *redis.Client
+	batchSize   int
+	keyChannel  chan string
+	wg          sync.WaitGroup
+	stopChannel chan struct{}
+}
+
+func NewKeyChecker(redisClient *redis.Client, batchSize int) *KeyChecker {
+	return &KeyChecker{
+		redisClient: redisClient,
+		batchSize:   batchSize,
+		keyChannel:  make(chan string, batchSize),
+		stopChannel: make(chan struct{}),
+	}
+}
+
+func (kc *KeyChecker) Start(ctx context.Context) {
+	kc.wg.Add(1)
+	go func() {
+		defer kc.wg.Done()
+		var keysBatch []string
+
+		for {
+			select {
+			case key := <-kc.keyChannel:
+				keysBatch = append(keysBatch, key)
+				if len(keysBatch) >= kc.batchSize {
+					kc.processBatch(ctx, keysBatch)
+					keysBatch = nil
+				}
+			case <-kc.stopChannel:
+				if len(keysBatch) > 0 {
+					kc.processBatch(ctx, keysBatch)
+				}
+				return
+			}
+		}
+	}()
+}
+
+func (kc *KeyChecker) Add(key string) {
+	kc.keyChannel <- key
+}
+
+func (kc *KeyChecker) Stop() {
+	close(kc.stopChannel)
+	kc.wg.Wait()
+}
+
+func (kc *KeyChecker) processBatch(ctx context.Context, keys []string) {
+	pipe := kc.redisClient.Pipeline()
+	defer pipe.Close()
+
+	for _, key := range keys {
+		pipe.Del(ctx, key)
+	}
+
+	_, err := pipe.Exec(ctx)
+	if err != nil {
+		log.Printf("Error deleting keys in batch: %v", err)
+	} else {
+		log.Printf("Successfully deleted %d keys", len(keys))
+	}
+}


### PR DESCRIPTION
## Summary
In Publish method (aws.go) when Set operations fails (which could be possibly due to redis server failure or any type of overhead) in that condition there is a chance that stale key could be stored.


### What?
in this PR I have added a method for successful deletion of the stale key using pipeline and batch deletion (source : redis/examples)  

