### PR TITLE
OH-2930: docs: architecture documentation and developer guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,114 @@
+# AGENTS.md — AI Agent Quick Reference for pubsublib
+
+## What this repo is
+
+A Go library (`github.com/Orange-Health/pubsublib`) that abstracts AWS SNS/SQS and Redis Pub/Sub behind a common `Provider` interface with optional middleware, gzip compression, and large-message Redis overflow.
+
+---
+
+## Key Files to Read First
+
+| File | Why |
+|---|---|
+| `pubsub.go` | Core types: `Client`, `Provider`, `Middleware`, `MessageHandler` |
+| `public.go` | `Client.Publish` + `chainPublisherMiddleware` |
+| `provider/aws/aws.go` | Primary production adapter (SNS publish, SQS poll, Redis overflow) |
+| `provider/redis/redis.go` | Redis Pub/Sub adapter |
+| `infrastructure/redis-client.go` | Singleton Redis client for overflow |
+| `helper/codec.go` | Gzip + Base64 utilities |
+| `helper/json_formatting.go` | camelCase → snake_case converter |
+
+---
+
+## Architecture in One Paragraph
+
+`pubsub.Client` holds a `Provider` and an ordered `Middleware` slice. When `Client.Publish` is called, middleware is chained in reverse order and the final call is delegated to `Provider.Publish`. `AWSPubSubAdapter` serialises the message to JSON, optionally compresses it, offloads payloads larger than 200 KB to Redis under a UUID key with a 2-minute TTL, validates required message attributes (`source`, `contains`, `event_type`), and calls `sns.Publish`. Consumers call `AWSPubSubAdapter.PollMessages`, which batches up to 10 SQS messages, verifies MD5 integrity, hydrates any Redis-offloaded bodies, decompresses if needed, calls the handler, and deletes the message from SQS.
+
+---
+
+## Interface Contracts
+
+### `Provider`
+```go
+type Provider interface {
+    Publish(topicARN string, message interface{}, messageAttributes map[string]interface{}) error
+    PollMessages(queueURL string, handler MessageHandler) error
+}
+```
+
+### `Middleware`
+```go
+type Middleware interface {
+    PublisherMsgInterceptor(serviceName string, next PublishHandler) PublishHandler
+}
+```
+
+### `MessageHandler`
+```go
+type MessageHandler func(message string) error
+```
+
+---
+
+## Required Message Attributes
+
+Every `Publish` call must include:
+
+```go
+map[string]interface{}{
+    "source":     "service-name",
+    "contains":   "entity-type",
+    "event_type": "event.name",   // AWS adapter
+    // "eventType": "eventName",  // Redis adapter
+}
+```
+
+`trace_id` is auto-injected as a UUID v4 if absent.
+
+---
+
+## Environment Variables
+
+| Variable | Effect |
+|---|---|
+| `PUBSUBLIB_COMPRESSION_ENABLED=true` | Enable gzip+base64 compression on publish |
+
+---
+
+## Safe Defaults
+
+- `NoopProvider` is the default — safe to import the library without any configuration.
+- `pubsub.SetClient(&pubsub.Client{Provider: myMock})` to inject a mock in tests.
+
+---
+
+## Branching Conventions (for PRs and commits)
+
+| Scenario | Branch pattern |
+|---|---|
+| New feature | `feature/<JIRAID>-<kebab-description>` from `dev` → PR to `dev` |
+| Hotfix | `hotfix/<JIRAID>-<kebab-description>` from `main` → PR to `main` + `dev` + `release` |
+| Release | `release` cut from `dev`; tagged `RC-YY.MMDD.BUILDCOUNT` during stabilisation |
+| Production tag | `vYY.MMDD.PATCHCOUNT` applied to `main` after release merge |
+
+---
+
+## What NOT to do
+
+- Do **not** assign `AWSPubSubAdapter` to `pubsub.Client.Provider` — signatures are incompatible.
+- Do **not** call `NewRedisDatabase` multiple times expecting different pools — it is a singleton.
+- Do **not** rename `messageAttributs` in `provider/redis/redis.go` without a consumer migration — it is a backwards-compatible typo.
+- Do **not** delete or move existing version tags — they are immutable module references.
+
+---
+
+## Documentation Index
+
+| Document | Topic |
+|---|---|
+| `docs/architecture/overview.md` | Component map, publish/consume flows, package layout |
+| `docs/architecture/service-layer.md` | Layer-by-layer breakdown with code references |
+| `docs/architecture/integrations.md` | AWS SNS, SQS, Redis integration details and contracts |
+| `docs/architecture/configuration.md` | All constructor params, env vars, and compile-time constants |
+| `docs/architecture/observability.md` | Built-in tracing, logging, and instrumentation patterns |
+| `docs/architecture/branching.md` | Branch model, naming conventions, versioning scheme |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,170 @@
+# CLAUDE.md — Developer & AI Agent Guide for pubsublib
+
+## Repository Purpose
+
+`pubsublib` is a Go library (`github.com/Orange-Health/pubsublib`) that provides a unified publish/subscribe abstraction over AWS SNS/SQS and Redis. Consuming services import the library and interact through a single `Provider` interface without coupling business logic to a specific broker.
+
+---
+
+## Directory Map
+
+```
+pubsublib/
+├── pubsub.go               # Core types: Client, Provider, Middleware, MessageHandler, SetClient
+├── public.go               # Client.Publish implementation + chainPublisherMiddleware
+├── noop.go                 # NoopProvider — default stub (no-ops all calls)
+│
+├── provider/
+│   ├── aws/
+│   │   └── aws.go          # AWSPubSubAdapter: SNS publish, SQS poll, Redis overflow, compression
+│   └── redis/
+│       └── redis.go        # RedisPubSubAdapter: native Redis Pub/Sub
+│
+├── infrastructure/
+│   └── redis-client.go     # Singleton RedisDatabase (go-redis/v8); key prefix PUBSUB:
+│
+├── helper/
+│   ├── codec.go            # Gzip compress/decompress + Base64 encode/decode
+│   └── json_formatting.go  # Recursive camelCase → snake_case map key converter
+│
+├── docs/
+│   └── architecture/       # Architecture documentation (Mermaid diagrams)
+│       ├── overview.md
+│       ├── service-layer.md
+│       ├── integrations.md
+│       ├── configuration.md
+│       ├── observability.md
+│       └── branching.md
+│
+├── .github/
+│   ├── CODEOWNERS
+│   └── PULL_REQUEST_TEMPLATE.md
+│
+├── CLAUDE.md               # This file
+├── AGENTS.md               # Agent-focused quick reference
+└── README.md
+```
+
+---
+
+## Layering Model
+
+```
+Consumer Service
+     │
+     ▼
+pubsub.Client  (+ Middleware chain)
+     │
+     ▼
+Provider interface
+     │
+     ├── AWSPubSubAdapter   (production)
+     │       ├── AWS SNS    (publish)
+     │       ├── AWS SQS    (consume)
+     │       └── RedisDatabase (overflow for payloads > 200 KB)
+     │
+     ├── RedisPubSubAdapter (dev / intra-service)
+     │       └── Redis Pub/Sub
+     │
+     └── NoopProvider       (test / default)
+```
+
+---
+
+## Key Conventions
+
+### Message attributes (required on every publish)
+
+| Key | Description |
+|---|---|
+| `source` | Originating service identifier |
+| `contains` | Entity / resource type in the payload |
+| `event_type` | Snake-case semantic event name (AWS adapter) |
+| `eventType` | Camel-case semantic event name (Redis adapter) |
+
+`trace_id` is auto-generated (UUID v4) if not provided.
+
+### Body serialisation
+- Messages are JSON-marshalled before publishing.
+- Map keys are automatically converted to `snake_case` by `helper.ConvertBodyToSnakeCase`.
+
+### Large-message overflow
+- Bodies exceeding **200 KB** are stored in Redis under `PUBSUB:<uuid>` with a **2-minute TTL**.
+- The SNS body is replaced with a pointer string; the `redis_key` attribute carries the UUID.
+- Consumers transparently hydrate the body from Redis on `PollMessages`.
+
+### Compression
+- Set `PUBSUBLIB_COMPRESSION_ENABLED=true` to enable gzip + base64 encoding.
+- Or call `adapter.SetCompressionEnabled(true)` programmatically.
+- Compressed messages carry `compress="true"` in message attributes.
+
+---
+
+## Adding a New Feature
+
+### Adding a new Provider
+
+1. Create `provider/<name>/<name>.go`.
+2. Implement the `pubsub.Provider` interface:
+   ```go
+   type Provider interface {
+       Publish(topicARN string, message interface{}, messageAttributes map[string]interface{}) error
+       PollMessages(queueURL string, handler MessageHandler) error
+   }
+   ```
+3. Export a `New<Name>PubSubAdapter(...)` constructor.
+4. Update `docs/architecture/integrations.md` and `docs/architecture/overview.md`.
+
+### Adding a new Middleware
+
+1. Implement `pubsub.Middleware`:
+   ```go
+   type Middleware interface {
+       PublisherMsgInterceptor(serviceName string, next PublishHandler) PublishHandler
+   }
+   ```
+2. Register it in `Client.Middleware` at construction time.
+3. Document any new observability signals in `docs/architecture/observability.md`.
+
+### Modifying message attribute handling
+
+- Required attribute validation lives in `provider/aws/aws.go` (`Publish`) and `provider/redis/redis.go` (`Publish`).
+- Both providers must be updated consistently when adding new required attributes.
+
+---
+
+## Branching Rules
+
+| Branch | Usage |
+|---|---|
+| `main` | Production only; hotfixes directly |
+| `dev` | Integration; all feature PRs target here |
+| `release` | Cut from `dev`; RC tags applied here |
+| `feature/<JIRAID>-<name>` | Feature work; branches from and merges into `dev` |
+| `hotfix/<JIRAID>-<desc>` | Urgent fixes; branches from `main`; merges into `main` + `dev` + `release` |
+
+### Versioning
+- Production: `YY.MMDD.PATCHCOUNT` (e.g. `v26.0401.1`)
+- Release candidate: `RC-YY.MMDD.BUILDCOUNT`
+- Staging: `vstag-b<NN>`, `vstagsandbox-b<NN>`
+
+---
+
+## Running Tests
+
+Since the library has no `go.mod` at root (it is a module published from the repo root via GitHub), tests are run from each package directory:
+
+```bash
+go test ./...
+```
+
+Use `NoopProvider` or pass a mock `Provider` implementation via `pubsub.SetClient` in tests — no real AWS or Redis connection required.
+
+---
+
+## Common Gotchas
+
+1. **`AWSPubSubAdapter` does not implement `pubsub.Provider`** — its `Publish` and `PollMessages` signatures differ (extra FIFO parameters, typed SQS handler). Use it directly; do not assign it to `pubsub.Client.Provider`.
+2. **`NewRedisDatabase` is a singleton** — passing different parameters on a second call has no effect; the original connection pool is returned.
+3. **`redis_key` typo in Redis adapter** — `messageAttributs` (missing 'e') is intentional for backwards compatibility; do not "fix" it without a migration plan.
+4. **Compression is checked at construction time** — changing `PUBSUBLIB_COMPRESSION_ENABLED` after the adapter is created has no effect unless `SetCompressionEnabled` is called explicitly.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # pubsublib
 Common pubsub library to be used across OH libraries
+
+## Getting Started
+
+To use pubsublib in your golang service use
+
+```sh
+go get -u github.com/Orange-Health/pubsublib@v0.3.3
+```
+
+### Quick Start
+
+Import package
+```go
+	pubsub "github.com/Orange-Health/pubsublib/provider/aws"
+```
+
+and initialize 
+
+```go
+
+    
+	awsAdapter, err := pubsub.NewAWSPubSubAdapter(
+		"aws-region",
+		"SQSAccessKeyID",
+		"SQSSecretAccessKey",
+		"SQSEndpointOverride",
+		"PubSubRedisHost",
+		"PubSubRedisPass",
+		PubSubRedisDb,
+		PubSubRedisPoolSize,
+		PubSubRedisMinIdleConn,
+	)
+	if err != nil {
+		errorService.LogError("Error while creating AWS adapter", err, nil)
+		return
+	}
+
+	awsAdapter.SetCompressionEnabled(true)
+```
+
+#### Using AWS IAM Roles for Service Accounts 
+
+Pass `region`, `accessKeyId` and `secretAccessKey` as empty strings to intialize AWS SDK without credentials, effectively falling back to Service Accounts

--- a/docs/architecture/branching.md
+++ b/docs/architecture/branching.md
@@ -1,0 +1,125 @@
+# Branching Strategy
+
+---
+
+## Branch Model
+
+```mermaid
+gitGraph
+   commit id: "init"
+
+   branch dev
+   checkout dev
+   commit id: "dev baseline"
+
+   branch feature/OH-1001-redis-adapter
+   checkout feature/OH-1001-redis-adapter
+   commit id: "add redis adapter"
+   commit id: "tests"
+   checkout dev
+   merge feature/OH-1001-redis-adapter id: "merge feature → dev"
+
+   branch feature/OH-1002-compression
+   checkout feature/OH-1002-compression
+   commit id: "gzip compress"
+   commit id: "base64 encode"
+   checkout dev
+   merge feature/OH-1002-compression id: "merge compression → dev"
+
+   branch release
+   checkout release
+   merge dev id: "cut release from dev"
+   commit id: "RC-26.0401.001"
+
+   checkout main
+   merge release id: "promote to main" tag: "26.0401.1"
+
+   branch hotfix/OH-5001-overflow-ttl
+   checkout hotfix/OH-5001-overflow-ttl
+   commit id: "fix redis TTL"
+   checkout main
+   merge hotfix/OH-5001-overflow-ttl id: "hotfix → main" tag: "26.0401.2"
+   checkout dev
+   merge hotfix/OH-5001-overflow-ttl id: "hotfix → dev"
+   checkout release
+   merge hotfix/OH-5001-overflow-ttl id: "hotfix → release"
+```
+
+---
+
+## Branch Definitions
+
+| Branch | Created from | Merges into | Purpose |
+|---|---|---|---|
+| `main` | — | — | Production-grade code; every commit is a releasable version |
+| `dev` | `main` | `release` | Integration branch; all feature work lands here first |
+| `release` | `dev` | `main` | Release stabilisation; only bug fixes committed here |
+| `feature/<JIRAID>-<name>` | `dev` | `dev` | New features or enhancements |
+| `hotfix/<JIRAID>-<desc>` | `main` | `main` + `dev` + `release` | Critical production bug fixes |
+
+---
+
+## Branch Naming Conventions
+
+### Feature branches
+```
+feature/<JIRA-ID>-<kebab-case-description>
+```
+Examples:
+- `feature/OH-1234-redis-overflow`
+- `feature/SB-345-gzip-compression`
+
+### Hotfix branches
+```
+hotfix/<JIRA-ID>-<kebab-case-description>
+```
+Examples:
+- `hotfix/OH-5001-fix-message-ttl`
+- `hotfix/OH-5002-md5-mismatch`
+
+---
+
+## Versioning Scheme
+
+### Production releases (semver-compatible Go module tags)
+```
+YY.MMDD.PATCHCOUNT
+```
+
+| Segment | Description | Example |
+|---|---|---|
+| `YY` | Two-digit year | `26` (2026) |
+| `MMDD` | Zero-padded month + day | `0401` (April 1st) |
+| `PATCHCOUNT` | Sequential patch number starting at 1 | `1`, `2`, `3` |
+
+Full examples: `v26.0401.1`, `v26.0401.2`
+
+> The existing `v0.3.x` semver tags (e.g. `v0.3.3`) represent the legacy versioning scheme prior to this convention.
+
+### Release candidates
+```
+RC-YY.MMDD.BUILDCOUNT
+```
+
+Examples: `RC-26.0401.001`, `RC-26.0401.002`
+
+Used on the `release` branch during stabilisation.
+
+### Staging / sandbox builds
+```
+vstag-b<NN>          # staging
+vstagsandbox-b<NN>   # sandbox
+stag-<desc>          # descriptive staging tag
+```
+
+Examples: `vstag-b14`, `vstagsandbox-b03`, `stag-compression-test`
+
+---
+
+## Lifecycle Rules
+
+1. **Feature branches** are short-lived — branch from `dev`, open a PR back to `dev`, delete after merge.
+2. **Release branches** are cut when `dev` is stable; only bug fixes are committed directly; promoted to `main` via PR when ready.
+3. **Hotfixes** must be cherry-picked (or merged) into **all** three long-running branches: `main`, `dev`, and `release`.
+4. **`main` is protected** — direct pushes are not allowed; all changes arrive via PR.
+5. **Tags are immutable** — never delete or move an existing version tag.

--- a/docs/architecture/configuration.md
+++ b/docs/architecture/configuration.md
@@ -1,0 +1,126 @@
+# Configuration
+
+This document lists every configuration surface exposed by `pubsublib` — constructor parameters, environment variables, and runtime toggles.
+
+---
+
+## AWS Adapter — Constructor Parameters
+
+`provider/aws.NewAWSPubSubAdapter` accepts all configuration at construction time:
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `region` | `string` | Yes | AWS region (e.g. `ap-south-1`) |
+| `accessKeyId` | `string` | No* | AWS access key ID. Pass `""` to use IRSA / instance profile |
+| `secretAccessKey` | `string` | No* | AWS secret access key. Pass `""` to use IRSA / instance profile |
+| `snsEndpoint` | `string` | No | Override SNS endpoint URL (e.g. `http://localhost:4566` for LocalStack). Pass `""` for the default AWS endpoint |
+| `redisAddress` | `string` | Yes | Redis host:port for the overflow store (e.g. `localhost:6379`) |
+| `redisPassword` | `string` | No | Redis AUTH password; pass `""` for no auth |
+| `redisDB` | `int` | Yes | Redis logical database index |
+| `redisPoolSize` | `int` | Yes | Maximum number of Redis connections in the pool |
+| `redisMinIdleConn` | `int` | Yes | Minimum number of idle Redis connections kept alive |
+
+\* Pass empty strings for both `accessKeyId` and `secretAccessKey` to enable **IRSA / IAM Role** credential chain.
+
+### Example — static credentials
+
+```go
+adapter, err := aws.NewAWSPubSubAdapter(
+    "ap-south-1",
+    os.Getenv("AWS_ACCESS_KEY_ID"),
+    os.Getenv("AWS_SECRET_ACCESS_KEY"),
+    "",           // use default SNS endpoint
+    "redis:6379",
+    "",           // no redis password
+    0, 10, 2,
+)
+```
+
+### Example — IRSA (Kubernetes service accounts)
+
+```go
+adapter, err := aws.NewAWSPubSubAdapter(
+    "ap-south-1",
+    "", "",       // empty → SDK uses IRSA / instance metadata
+    "",
+    "redis:6379",
+    "", 0, 10, 2,
+)
+```
+
+---
+
+## Environment Variables
+
+| Variable | Values | Default | Description |
+|---|---|---|---|
+| `PUBSUBLIB_COMPRESSION_ENABLED` | `true`, `1` | disabled | Enable gzip + base64 compression of message bodies before publishing. Checked once at `NewAWSPubSubAdapter` construction time. |
+
+### Setting compression at runtime
+
+Compression can also be toggled programmatically after construction:
+
+```go
+adapter.SetCompressionEnabled(true)  // enable
+adapter.SetCompressionEnabled(false) // disable
+```
+
+---
+
+## Redis Adapter — Constructor Parameters
+
+`provider/redis.NewRedisPubSubAdapter` takes a single address parameter:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `addr` | `string` | Redis address in `host:port` format |
+
+---
+
+## Redis Infrastructure — Singleton Configuration
+
+`infrastructure.NewRedisDatabase` is a singleton factory:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `address` | `string` | Redis `host:port` |
+| `password` | `string` | Redis AUTH password (`""` for none) |
+| `db` | `int` | Logical DB index |
+| `poolSize` | `int` | Max active connections |
+| `minIdleConn` | `int` | Min idle connections |
+
+Once initialised, subsequent calls return the existing instance regardless of parameters passed.
+
+---
+
+## Message Attribute Requirements
+
+The following keys must be present in `messageAttributes` for every publish call:
+
+| Key | Provider | Description |
+|---|---|---|
+| `source` | AWS + Redis | Service name or identifier originating the event |
+| `contains` | AWS + Redis | Entity / resource type the event carries |
+| `event_type` | AWS | Snake-case semantic event name |
+| `eventType` | Redis | Camel-case semantic event name (Redis adapter convention) |
+| `trace_id` | AWS | Distributed trace ID; auto-populated with UUID v4 if missing |
+
+---
+
+## Large-Message Overflow Thresholds
+
+| Threshold | Value | Behaviour |
+|---|---|---|
+| Body size limit | 200 KB (`200 * 1024` bytes) | Payload stored in Redis; body replaced with pointer string |
+| Redis key TTL | 2 minutes | Keys expire automatically if not consumed |
+
+---
+
+## Compile-Time / Package Defaults
+
+| Constant | Value | Location | Description |
+|---|---|---|---|
+| `keyPrefix` | `"PUBSUB"` | `infrastructure/redis-client.go` | Prefix for all Redis keys |
+| Default provider | `NoopProvider{}` | `pubsub.go` | Active when no adapter is explicitly set |
+| SQS visibility timeout | `5 s` | `provider/aws/aws.go` | Per-message processing window |
+| SQS max messages | `10` | `provider/aws/aws.go` | Batch size per `ReceiveMessage` call |

--- a/docs/architecture/integrations.md
+++ b/docs/architecture/integrations.md
@@ -1,0 +1,194 @@
+# Integrations
+
+`pubsublib` integrates with three external systems: **AWS SNS**, **AWS SQS**, and **Redis**. This document describes each integration, its configuration surface, and the data contracts it enforces.
+
+---
+
+## Integration Map
+
+```mermaid
+graph LR
+    subgraph pubsublib
+        ADP[AWSPubSubAdapter]
+        RDBMS[RedisDatabase]
+        RADP[RedisPubSubAdapter]
+    end
+
+    subgraph AWS
+        SNS[SNS\nTopic]
+        SQS[SQS\nQueue]
+    end
+
+    subgraph Redis
+        RDB[(Redis)]
+    end
+
+    ADP -->|sns.Publish| SNS
+    SNS -.->|fan-out| SQS
+    ADP -->|sqs.ReceiveMessage\nsqs.DeleteMessage| SQS
+    ADP -->|Set / Get large payloads| RDBMS
+    RDBMS --> RDB
+    RADP -->|PUBLISH / SUBSCRIBE| RDB
+```
+
+---
+
+## 1. AWS SNS
+
+### Purpose
+Publishing messages to SNS topics; fan-out to one or more SQS queues is handled by AWS infrastructure.
+
+### SDK
+`github.com/aws/aws-sdk-go` — `service/sns`
+
+### Session initialisation
+```go
+// Static credentials (CI, local dev)
+awsConfig.Credentials = credentials.NewStaticCredentials(accessKeyId, secretAccessKey, "")
+
+// IRSA / Instance profile (Kubernetes, ECS) — pass empty strings
+awsConfig := &aws.Config{Region: aws.String(region)}
+sess, _ := session.NewSession(awsConfig)
+```
+
+### Endpoint override
+Set `snsEndpoint` to a non-empty string (e.g. `http://localhost:4566` for LocalStack) to redirect all SNS calls.
+
+### Standard topic publish
+
+```go
+ps.snsSvc.Publish(&sns.PublishInput{
+    Message:           aws.String(messageBody),
+    TopicArn:          aws.String(topicARN),
+    MessageAttributes: awsMessageAttributes,
+})
+```
+
+### FIFO topic publish
+
+For `.fifo` topics, pass `messageGroupId` and `messageDeduplicationId`:
+
+```go
+publishMessage.MessageGroupId          = aws.String(messageGroupId)
+publishMessage.MessageDeduplicationId = aws.String(messageDeduplicationId)
+```
+
+### Required message attributes
+
+| Attribute | Type | Description |
+|---|---|---|
+| `source` | `String` | Originating service identifier |
+| `contains` | `String` | Entity type carried in the payload |
+| `event_type` | `String` | Semantic event name (e.g. `user.created`) |
+| `trace_id` | `String` | Distributed trace ID; auto-generated (UUID v4) if absent |
+
+### Optional message attributes
+
+| Attribute | Type | Set by |
+|---|---|---|
+| `compress` | `String` (`"true"`) | Library when compression is enabled |
+| `redis_key` | `String` (UUID) | Library when payload exceeds 200 KB |
+
+---
+
+## 2. AWS SQS
+
+### Purpose
+Polling and consuming messages forwarded by SNS fan-out subscriptions.
+
+### SDK
+`github.com/aws/aws-sdk-go` — `service/sqs` / `sqsiface`
+
+### Poll parameters
+
+| Parameter | Value | Notes |
+|---|---|---|
+| `MaxNumberOfMessages` | `10` | Maximum batch per call |
+| `VisibilityTimeout` | `5 s` | Window to process before message re-appears |
+| `MessageAttributeNames` | `["All"]` | Retrieve all custom attributes |
+| `AttributeNames` | `["All"]` | Retrieve all system attributes |
+
+### Message lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Received: ReceiveMessage
+    Received --> IntegrityCheck
+    IntegrityCheck --> HydrateRedis: redis_key present
+    IntegrityCheck --> Decompress: compress = true
+    HydrateRedis --> Decompress
+    Decompress --> HandlerInvoked
+    HandlerInvoked --> Deleted: handler returns nil
+    HandlerInvoked --> [*]: handler returns error (message becomes visible again)
+    Deleted --> [*]
+```
+
+### Message integrity
+Each message body is MD5-hashed and compared against the `MD5OfBody` field provided by SQS. A mismatch returns an error and halts processing of the batch.
+
+---
+
+## 3. Redis — Overflow Store (`infrastructure/RedisDatabase`)
+
+### Purpose
+Transparently storing message bodies that exceed the SNS/SQS 256 KB limit.
+
+### SDK
+`github.com/go-redis/redis/v8`
+
+### Key schema
+
+```
+PUBSUB:<uuid>
+```
+
+- TTL: **2 minutes** (hardcoded)
+- Value: JSON-serialised message body (string)
+- The UUID is generated at publish time and passed as the `redis_key` SNS message attribute.
+
+### Connection options
+
+| Option | Constructor parameter |
+|---|---|
+| Address | `redisAddress` |
+| Password | `redisPassword` |
+| DB index | `redisDB` |
+| Pool size | `redisPoolSize` |
+| Min idle conns | `redisMinIdleConn` |
+
+### Singleton behaviour
+`NewRedisDatabase` returns the existing `Rdb` singleton on subsequent calls — safe to call multiple times; only one connection pool is created per process.
+
+---
+
+## 4. Redis — Pub/Sub Transport (`provider/redis/RedisPubSubAdapter`)
+
+### Purpose
+Native Redis Pub/Sub as an alternative to SNS/SQS (primarily for local development and intra-service communication).
+
+### SDK
+`github.com/go-redis/redis/v8`
+
+### Publish contract
+Wraps message and attributes into:
+```json
+{
+  "messageAttributs": { "source": "...", "contains": "...", "eventType": "..." },
+  "message": { ... }
+}
+```
+> Note: `messageAttributs` is a known typo preserved for backwards compatibility.
+
+### Subscribe behaviour
+`PollMessages` opens a subscription on the given topic channel and loops indefinitely, invoking the handler for each received payload. The subscriber blocks until the context or channel is closed.
+
+---
+
+## Dependency Versions
+
+| Library | Import path | Purpose |
+|---|---|---|
+| aws-sdk-go | `github.com/aws/aws-sdk-go` | SNS/SQS client |
+| go-redis | `github.com/go-redis/redis/v8` | Redis client |
+| uuid | `github.com/google/uuid` | UUID v4 generation |
+| errors | `github.com/pkg/errors` | Error wrapping |

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,0 +1,176 @@
+# Observability
+
+This document describes the built-in observability primitives in `pubsublib` and recommended patterns for adding instrumentation in consuming services.
+
+---
+
+## Built-in Observability
+
+### Distributed Tracing — `trace_id`
+
+Every publish call automatically injects a `trace_id` message attribute if one is not already provided by the caller:
+
+```go
+if messageAttributes["trace_id"] == nil {
+    messageAttributes["trace_id"] = uuid.New().String()
+}
+```
+
+`trace_id` is propagated as an SNS message attribute and is available to consumers via `message.MessageAttributes["trace_id"]`. Services should read this value and forward it to their internal tracing infrastructure (e.g. OpenTelemetry, Datadog).
+
+---
+
+### Error Surfaces
+
+All errors are returned up the call stack — the library does not swallow errors silently. The following operations return errors that callers must handle:
+
+| Operation | Error condition |
+|---|---|
+| `NewAWSPubSubAdapter` | AWS session creation fails; Redis ping fails |
+| `Publish` | Missing required attributes; JSON marshal failure; Redis Set failure; SNS API error |
+| `PollMessages` | SQS ReceiveMessage failure; MD5 mismatch; Redis Get failure; handler returns error; SQS DeleteMessage failure |
+| `NewRedisDatabase` | Redis ping fails |
+
+---
+
+### Structured Log Statements
+
+The infrastructure layer emits log lines via the standard `log` package:
+
+| Location | Event |
+|---|---|
+| `infrastructure/redis-client.go` | Key not found in Redis (`"Key does not exist: <key>"`) |
+| `infrastructure/redis-client.go` | Redis Get error (`"Error while fetching data from redis. Key,value ..."`) |
+| `infrastructure/redis-client.go` | JSON unmarshal error |
+| `infrastructure/redis-client.go` | Key deletion (`"Deleting following key from redis: <key>"`) |
+
+---
+
+## Recommended Instrumentation Patterns
+
+### 1. Publish Latency & Error Rate via Middleware
+
+Implement `pubsub.Middleware` to wrap every publish call with metrics and traces:
+
+```go
+type InstrumentedMiddleware struct {
+    meter  metric.Meter   // OpenTelemetry meter
+    tracer trace.Tracer   // OpenTelemetry tracer
+}
+
+func (m *InstrumentedMiddleware) PublisherMsgInterceptor(
+    serviceName string,
+    next pubsub.PublishHandler,
+) pubsub.PublishHandler {
+    return func(topicARN string, msg interface{}, attrs map[string]interface{}) error {
+        ctx, span := m.tracer.Start(context.Background(), "pubsub.publish",
+            trace.WithAttributes(
+                attribute.String("topic", topicARN),
+                attribute.String("service", serviceName),
+            ),
+        )
+        defer span.End()
+
+        start := time.Now()
+        err := next(topicARN, msg, attrs)
+        duration := time.Since(start)
+
+        // record metrics
+        m.meter.Int64Histogram("pubsub.publish.duration_ms").Record(ctx, duration.Milliseconds())
+        if err != nil {
+            span.RecordError(err)
+            m.meter.Int64Counter("pubsub.publish.errors").Add(ctx, 1)
+        }
+        return err
+    }
+}
+```
+
+Register it at client construction:
+
+```go
+client := &pubsub.Client{
+    ServiceName: "my-service",
+    Provider:    awsAdapter,
+    Middleware:  []pubsub.Middleware{&InstrumentedMiddleware{meter, tracer}},
+}
+```
+
+---
+
+### 2. Consumer Observability
+
+Because `PollMessages` accepts a handler function, consumers instrument the handler directly:
+
+```go
+awsAdapter.PollMessages(queueURL, func(msg *sqs.Message) error {
+    traceID := ""
+    if attr, ok := msg.MessageAttributes["trace_id"]; ok && attr.StringValue != nil {
+        traceID = *attr.StringValue
+    }
+
+    ctx := injectTraceID(context.Background(), traceID)
+    _, span := tracer.Start(ctx, "pubsub.consume")
+    defer span.End()
+
+    start := time.Now()
+    err := processMessage(msg)
+    recordConsumerMetrics(time.Since(start), err)
+    return err
+})
+```
+
+---
+
+### 3. Recommended Metrics
+
+| Metric name | Type | Labels | Description |
+|---|---|---|---|
+| `pubsub.publish.duration_ms` | Histogram | `topic`, `service`, `status` | End-to-end publish latency |
+| `pubsub.publish.errors` | Counter | `topic`, `service`, `error_type` | Publish error count |
+| `pubsub.consume.duration_ms` | Histogram | `queue`, `service`, `status` | Handler processing latency |
+| `pubsub.consume.errors` | Counter | `queue`, `service`, `error_type` | Consumer error count |
+| `pubsub.redis_overflow.count` | Counter | `topic` | Messages offloaded to Redis |
+| `pubsub.compression.count` | Counter | `topic` | Messages compressed |
+
+---
+
+### 4. Alerting Recommendations
+
+| Signal | Suggested threshold | Severity |
+|---|---|---|
+| Publish error rate | > 1% over 5 min | Warning |
+| Publish error rate | > 5% over 2 min | Critical |
+| Consumer error rate | > 1% over 5 min | Warning |
+| SQS queue depth (CloudWatch) | > 1000 messages | Warning |
+| Redis key count `PUBSUB:*` | > 500 | Warning (overflow volume spike) |
+| Redis connection pool saturation | > 90% | Critical |
+
+---
+
+## Observability Architecture Diagram
+
+```mermaid
+graph TD
+    subgraph pubsublib
+        MW[Middleware\nInstrumentation]
+        PUB[Publish]
+        CONS[PollMessages / Handler]
+    end
+
+    subgraph Telemetry
+        OT[OpenTelemetry SDK]
+        PROM[Prometheus / Datadog]
+        JAEGER[Jaeger / Tempo\nTrace Backend]
+    end
+
+    subgraph AWS
+        CW[CloudWatch\nSQS Queue Depth]
+    end
+
+    MW -->|spans + metrics| OT
+    CONS -->|spans + metrics| OT
+    OT --> PROM
+    OT --> JAEGER
+    CW -.->|external alert| PROM
+```

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,166 @@
+# pubsublib — Architecture Overview
+
+`pubsublib` is a Go library that provides a unified publish/subscribe abstraction over multiple message-transport backends. Consuming services import the library, initialise the adapter of their choice, and interact through a single, stable API surface — without coupling their business logic to a specific broker.
+
+---
+
+## High-Level Component Map
+
+```mermaid
+graph TD
+    subgraph Consumers["Consumer Services"]
+        SVC[Your Go Service]
+    end
+
+    subgraph Core["pubsublib Core (package pubsub)"]
+        CLIENT[Client]
+        MW[Middleware Chain]
+        IFACE[Provider Interface]
+    end
+
+    subgraph Providers["Transport Providers"]
+        AWS[provider/aws — AWSPubSubAdapter]
+        REDIS[provider/redis — RedisPubSubAdapter]
+        NOOP[NoopProvider]
+    end
+
+    subgraph Infrastructure["Infrastructure Helpers"]
+        RDBMS[infrastructure/RedisDatabase\nOverflow Store]
+        HELPER_CODEC[helper/codec\nGzip + Base64]
+        HELPER_JSON[helper/json_formatting\nSnake-case Converter]
+    end
+
+    subgraph External["External Services"]
+        SNS[AWS SNS]
+        SQS[AWS SQS]
+        RDB[Redis]
+    end
+
+    SVC -->|pubsub.Client.Publish| CLIENT
+    CLIENT --> MW
+    MW --> IFACE
+    IFACE --> AWS
+    IFACE --> REDIS
+    IFACE --> NOOP
+
+    AWS --> HELPER_CODEC
+    AWS --> HELPER_JSON
+    AWS --> RDBMS
+    AWS --> SNS
+    AWS --> SQS
+
+    RDBMS --> RDB
+    REDIS --> RDB
+```
+
+---
+
+## Core Abstractions
+
+| Abstraction | Location | Purpose |
+|---|---|---|
+| `Provider` | `pubsub.go` | Interface that every transport adapter implements (`Publish`, `PollMessages`) |
+| `Client` | `pubsub.go` | Holds a `Provider` reference and an ordered `Middleware` slice; exposes `Publish` |
+| `Middleware` | `pubsub.go` | Interceptor interface; allows cross-cutting concerns (logging, tracing, retry) on publish |
+| `MessageHandler` | `pubsub.go` | `func(string) error` callback used by the base provider contract |
+| `NoopProvider` | `noop.go` | No-op implementation; default out-of-the-box so tests never need real brokers |
+
+---
+
+## Publish Flow
+
+```mermaid
+sequenceDiagram
+    participant SVC as Consumer Service
+    participant CLI as pubsub.Client
+    participant MWC as Middleware Chain
+    participant PRV as Provider (AWS / Redis)
+    participant SNS as AWS SNS
+    participant RDB as Redis (overflow)
+
+    SVC->>CLI: Publish(topicARN, message, attrs)
+    CLI->>MWC: chainPublisherMiddleware(...)
+    MWC->>PRV: PublishHandler(topicARN, message, attrs)
+    alt message > 200 KB
+        PRV->>RDB: Set(uuid, body, 2 min TTL)
+        PRV-->>PRV: replace body with redis pointer
+    end
+    alt compression enabled
+        PRV-->>PRV: Gzip + Base64 encode
+        PRV-->>PRV: set attrs["compress"]="true"
+    end
+    PRV->>SNS: sns.Publish(...)
+    SNS-->>PRV: MessageId
+    PRV-->>CLI: nil / error
+    CLI-->>SVC: nil / error
+```
+
+---
+
+## Poll / Consume Flow
+
+```mermaid
+sequenceDiagram
+    participant WORKER as Consumer Worker
+    participant ADP as AWSPubSubAdapter
+    participant SQS as AWS SQS
+    participant RDB as Redis (overflow)
+    participant HDL as MessageHandler
+
+    WORKER->>ADP: PollMessages(queueURL, handler)
+    ADP->>SQS: ReceiveMessage (batch ≤10)
+    SQS-->>ADP: []Message
+    loop for each message
+        ADP->>ADP: MD5 integrity check
+        opt redis_key attribute present
+            ADP->>RDB: Get(redis_key)
+            RDB-->>ADP: full body
+        end
+        opt SNS envelope detected
+            ADP->>ADP: unwrap Message field
+        end
+        opt compress attribute = true
+            ADP->>ADP: Base64Decode + Gunzip
+        end
+        ADP->>HDL: handler(message)
+        ADP->>SQS: DeleteMessage
+    end
+```
+
+---
+
+## Package Layout
+
+```
+pubsublib/
+├── pubsub.go               # Core types: Client, Provider, Middleware, MessageHandler
+├── public.go               # Client.Publish + middleware chaining
+├── noop.go                 # NoopProvider (default / test stub)
+│
+├── provider/
+│   ├── aws/
+│   │   └── aws.go          # AWSPubSubAdapter: SNS publish, SQS poll, Redis overflow
+│   └── redis/
+│       └── redis.go        # RedisPubSubAdapter: native Redis Pub/Sub
+│
+├── infrastructure/
+│   └── redis-client.go     # Singleton RedisDatabase (go-redis/v8); keys prefixed PUBSUB:
+│
+├── helper/
+│   ├── codec.go            # Gzip compress/decompress; Base64 encode/decode
+│   └── json_formatting.go  # Recursive camelCase → snake_case map conversion
+│
+└── .github/
+    ├── CODEOWNERS
+    └── PULL_REQUEST_TEMPLATE.md
+```
+
+---
+
+## Design Principles
+
+1. **Provider-agnostic interface** — swap AWS for Redis (or a future Kafka adapter) with zero changes to business logic.
+2. **Composable middleware** — interceptors stack in reverse-registration order, enabling clean separation of cross-cutting concerns without modifying the core path.
+3. **Large-message transparency** — payloads exceeding the SNS/SQS 256 KB limit are automatically offloaded to Redis; consumers transparently retrieve and hydrate the full body.
+4. **Optional compression** — gzip + base64 is opt-in via an environment variable, keeping the hot path lean for small payloads.
+5. **Zero-dependency default** — `NoopProvider` is registered as the default client so imported packages never panic during tests or cold starts.

--- a/docs/architecture/service-layer.md
+++ b/docs/architecture/service-layer.md
@@ -1,0 +1,198 @@
+# Service Layer
+
+This document describes every layer of the library from the public API surface down to the infrastructure utilities.
+
+---
+
+## Layer Diagram
+
+```mermaid
+graph TD
+    L1["Layer 1 — Public API\npubsub.Client  ·  pubsub.SetClient"]
+    L2["Layer 2 — Middleware\nMiddleware interface  ·  chainPublisherMiddleware"]
+    L3["Layer 3 — Provider Contract\nProvider interface"]
+    L4a["Layer 4a — AWS Adapter\nAWSPubSubAdapter"]
+    L4b["Layer 4b — Redis Adapter\nRedisPubSubAdapter"]
+    L4c["Layer 4c — Noop Adapter\nNoopProvider"]
+    L5a["Layer 5a — Infrastructure\nRedisDatabase (singleton)"]
+    L5b["Layer 5b — Helpers\ncodec · json_formatting"]
+
+    L1 --> L2 --> L3
+    L3 --> L4a
+    L3 --> L4b
+    L3 --> L4c
+    L4a --> L5a
+    L4a --> L5b
+```
+
+---
+
+## Layer 1 — Public API (`pubsub` package)
+
+### `Client`
+
+```go
+type Client struct {
+    ServiceName string
+    Provider    Provider
+    Middleware  []Middleware
+}
+```
+
+| Field | Description |
+|---|---|
+| `ServiceName` | Injected into every `PublisherMsgInterceptor` call; used for tracing/logging middleware |
+| `Provider` | The active transport backend |
+| `Middleware` | Ordered slice of interceptors applied on every `Publish` call |
+
+**`Client.Publish`** (`public.go`) chains all middleware in reverse-registration order then delegates to `Provider.Publish`.
+
+**`SetClient`** replaces the package-level `clients` singleton — intended for test setup to inject mocks.
+
+---
+
+## Layer 2 — Middleware (`pubsub` package)
+
+```go
+type Middleware interface {
+    PublisherMsgInterceptor(serviceName string, next PublishHandler) PublishHandler
+}
+```
+
+`chainPublisherMiddleware` wraps middleware in a LIFO stack so the first registered middleware is the outermost interceptor:
+
+```mermaid
+graph LR
+    PUB[Publish call] --> MW0["Middleware[0]\n(outermost)"] --> MW1["Middleware[1]"] --> FINAL[Provider.Publish]
+```
+
+Implementing a middleware:
+
+```go
+type LoggingMiddleware struct{}
+
+func (l LoggingMiddleware) PublisherMsgInterceptor(svcName string, next pubsub.PublishHandler) pubsub.PublishHandler {
+    return func(topicARN string, msg interface{}, attrs map[string]interface{}) error {
+        log.Printf("[%s] publishing to %s", svcName, topicARN)
+        err := next(topicARN, msg, attrs)
+        log.Printf("[%s] result: %v", svcName, err)
+        return err
+    }
+}
+```
+
+---
+
+## Layer 3 — Provider Contract
+
+```go
+type Provider interface {
+    Publish(topicARN string, message interface{}, messageAttributes map[string]interface{}) error
+    PollMessages(queueURL string, handler MessageHandler) error
+}
+```
+
+> **Note**: `AWSPubSubAdapter` intentionally does **not** implement the core `Provider` interface directly — its `Publish` and `PollMessages` signatures carry additional AWS-specific parameters (`messageGroupId`, `messageDeduplicationId`, typed SQS handler). Use `AWSPubSubAdapter` directly rather than through `pubsub.Client` when FIFO support is required.
+
+---
+
+## Layer 4a — AWS Adapter (`provider/aws`)
+
+**`AWSPubSubAdapter`** — the primary production adapter.
+
+### Construction
+
+```go
+func NewAWSPubSubAdapter(
+    region, accessKeyId, secretAccessKey string,
+    snsEndpoint string,
+    redisAddress, redisPassword string,
+    redisDB, redisPoolSize, redisMinIdleConn int,
+) (*AWSPubSubAdapter, error)
+```
+
+Pass empty strings for `accessKeyId` / `secretAccessKey` to use **IRSA** (IAM Roles for Service Accounts) — the SDK falls back to the environment credential chain.
+
+### Publish responsibilities
+
+1. Map keys converted to `snake_case` via `helper.ConvertBodyToSnakeCase`.
+2. JSON serialise the message.
+3. **Optional compression** — if `PUBSUBLIB_COMPRESSION_ENABLED=true|1`, gzip-compress and base64-encode; set `messageAttributes["compress"]="true"`.
+4. **Large-message overflow** — if serialised body > 200 KB, store in Redis under a UUID key (`PUBSUB:<uuid>`, TTL 2 min) and replace the body with a pointer string.
+5. Validate required attributes: `source`, `contains`, `event_type`. Auto-inject `trace_id` (UUID v4) if absent.
+6. Convert `messageAttributes` to `*sns.MessageAttributeValue` map via `BindAttributes`.
+7. Call `snsSvc.Publish`; optionally set `MessageGroupId` and `MessageDeduplicationId` for FIFO topics.
+
+### PollMessages responsibilities
+
+1. Receive up to 10 messages from SQS with a 5-second visibility timeout.
+2. MD5 integrity check — abort with error on mismatch.
+3. **Redis key hydration** — if `redis_key` attribute present, fetch body from Redis.
+4. **SNS envelope detection** — unwrap the `Message` field when the body is an SNS notification envelope.
+5. **Decompression** — Base64-decode then gunzip when `compress="true"`.
+6. Invoke handler; delete message from queue on success.
+
+### Attribute type mapping (`BindAttributes`)
+
+| Go type | SNS `DataType` |
+|---|---|
+| `string` | `String` |
+| `int`, `float64`, … | `Number` |
+| `[]string` | `String.Array` |
+
+---
+
+## Layer 4b — Redis Adapter (`provider/redis`)
+
+**`RedisPubSubAdapter`** — lightweight Redis Pub/Sub transport.
+
+```go
+func NewRedisPubSubAdapter(addr string) (*RedisPubSubAdapter, error)
+```
+
+- `Publish`: validates `source`, `contains`, `eventType` attributes; wraps message and attributes into a single JSON object; calls `client.Publish`.
+- `PollMessages`: subscribes to the topic channel; loops over `pubsub.Channel()` invoking the handler for each payload.
+
+> This adapter is suitable for **intra-datacenter** or **dev/test** scenarios where AWS is unavailable.
+
+---
+
+## Layer 4c — Noop Adapter (`noop.go`)
+
+`NoopProvider` silently discards all publish and poll calls. It is the package-level default, ensuring no nil-pointer panics when a service is initialised without an explicit adapter.
+
+---
+
+## Layer 5a — Infrastructure (`infrastructure/redis-client.go`)
+
+**`RedisDatabase`** wraps `go-redis/v8` with:
+
+| Feature | Detail |
+|---|---|
+| Singleton pattern | `NewRedisDatabase` returns the existing `Rdb` if already initialised |
+| Key prefix | All keys are stored as `PUBSUB:<key>` |
+| Pool configuration | `poolSize` / `minIdleConns` tunable at construction |
+| TTL unit | `Set` accepts `expiryTime` in **minutes** |
+| Liveness check | `client.Ping` at construction; returns error if unreachable |
+
+Operations: `Set`, `Get` (JSON marshal/unmarshal), `Delete`.
+
+---
+
+## Layer 5b — Helpers
+
+### `helper/codec.go`
+
+| Function | Description |
+|---|---|
+| `GzipCompress(data, level)` | Compress bytes at a given gzip level |
+| `GzipDecompress(data)` | Decompress gzip bytes |
+| `Base64Encode(data)` | Standard base64 encode |
+| `Base64Decode(s)` | Standard base64 decode |
+| `GzipAndBase64(data, level)` | Compress then encode — returns base64 string |
+| `GzipAndBase64Best(data)` | `GzipAndBase64` at `BestCompression` level |
+| `Base64DecodeAndGunzipIf(b64, compressed)` | Decode and conditionally decompress |
+
+### `helper/json_formatting.go`
+
+`ConvertBodyToSnakeCase` recursively walks a `map[string]interface{}` and converts every key from camelCase to snake_case. Handles nested maps and slices of maps.

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -30,20 +30,17 @@ type AWSPubSubAdapter struct {
 }
 
 func NewAWSPubSubAdapter(region, accessKeyId, secretAccessKey, snsEndpoint, redisAddress, redisPassword string, redisDB, redisPoolSize, redisMinIdleConn int) (*AWSPubSubAdapter, error) {
-	sess, err := session.NewSession()
-	if err != nil && accessKeyId == "" && secretAccessKey == "" {
+	awsConfig := &aws.Config{}
+	awsConfig.Endpoint = aws.String(snsEndpoint)
+	if accessKeyId != "" && secretAccessKey != "" {
+		awsConfig.Region = aws.String(region)
+		awsConfig.Credentials = credentials.NewStaticCredentials(accessKeyId, secretAccessKey, "")
+	}
+	sess, err := session.NewSession(awsConfig)
+	if err != nil {
 		return nil, err
 	}
-	if accessKeyId != "" && secretAccessKey != "" {
-		sess, err = session.NewSession(&aws.Config{
-			Region:      aws.String(region),
-			Endpoint:    aws.String(snsEndpoint),
-			Credentials: credentials.NewStaticCredentials(accessKeyId, secretAccessKey, ""),
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
+
 	snsSvc := sns.New(sess)
 	sqsSvc := sqs.New(sess)
 

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -135,18 +135,18 @@ func (ps *AWSPubSubAdapter) Publish(topicARN string, messageGroupId, messageDedu
 			return errors.Wrap(bindErr, "error binding attributes")
 		}
 	}
-	pubslishMessage := &sns.PublishInput{
+	publishMessage := &sns.PublishInput{
 		Message:           aws.String(messageBody),
 		TopicArn:          aws.String(topicARN),
 		MessageAttributes: awsMessageAttributes,
 	}
 	if messageGroupId != "" {
-		pubslishMessage.MessageGroupId = aws.String(messageGroupId)
+		publishMessage.MessageGroupId = aws.String(messageGroupId)
 	}
 	if messageDeduplicationId != "" {
-		pubslishMessage.MessageDeduplicationId = aws.String(messageDeduplicationId)
+		publishMessage.MessageDeduplicationId = aws.String(messageDeduplicationId)
 	}
-	_, err = ps.snsSvc.Publish(pubslishMessage)
+	_, err = ps.snsSvc.Publish(publishMessage)
 	if err != nil {
 		return err
 	}

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -31,7 +31,9 @@ type AWSPubSubAdapter struct {
 
 func NewAWSPubSubAdapter(region, accessKeyId, secretAccessKey, snsEndpoint, redisAddress, redisPassword string, redisDB, redisPoolSize, redisMinIdleConn int) (*AWSPubSubAdapter, error) {
 	awsConfig := &aws.Config{}
-	awsConfig.Endpoint = aws.String(snsEndpoint)
+	if snsEndpoint != "" {
+		awsConfig.Endpoint = aws.String(snsEndpoint)
+	}
 	if accessKeyId != "" && secretAccessKey != "" {
 		awsConfig.Region = aws.String(region)
 		awsConfig.Credentials = credentials.NewStaticCredentials(accessKeyId, secretAccessKey, "")

--- a/provider/aws/aws.go
+++ b/provider/aws/aws.go
@@ -1,69 +1,74 @@
 package aws
 
 import (
-    "crypto/md5"
-    "encoding/hex"
-    "encoding/json"
-    "fmt"
-    "os"
-    "strings"
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
 
-    "github.com/aws/aws-sdk-go/aws"
-    "github.com/aws/aws-sdk-go/aws/credentials"
-    "github.com/aws/aws-sdk-go/aws/session"
-    "github.com/aws/aws-sdk-go/service/sns"
-    "github.com/aws/aws-sdk-go/service/sqs"
-    "github.com/aws/aws-sdk-go/service/sqs/sqsiface"
-    "github.com/google/uuid"
-    "github.com/pkg/errors"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
 
-    "github.com/Orange-Health/pubsublib/helper"
-    "github.com/Orange-Health/pubsublib/infrastructure"
+	"github.com/Orange-Health/pubsublib/helper"
+	"github.com/Orange-Health/pubsublib/infrastructure"
 )
 
 type AWSPubSubAdapter struct {
-    session     *session.Session
-    snsSvc      *sns.SNS
-    sqsSvc      sqsiface.SQSAPI
-    redisClient *infrastructure.RedisDatabase
-    compressEnabled bool
+	session         *session.Session
+	snsSvc          *sns.SNS
+	sqsSvc          sqsiface.SQSAPI
+	redisClient     *infrastructure.RedisDatabase
+	compressEnabled bool
 }
 
 func NewAWSPubSubAdapter(region, accessKeyId, secretAccessKey, snsEndpoint, redisAddress, redisPassword string, redisDB, redisPoolSize, redisMinIdleConn int) (*AWSPubSubAdapter, error) {
-    sess, err := session.NewSession(&aws.Config{
-        Region:      aws.String(region),
-        Endpoint:    aws.String(snsEndpoint),
-        Credentials: credentials.NewStaticCredentials(accessKeyId, secretAccessKey, ""),
-    })
-    if err != nil {
-        return nil, err
-    }
+	sess, err := session.NewSession()
+	if err != nil && accessKeyId == "" && secretAccessKey == "" {
+		return nil, err
+	}
+	if accessKeyId != "" && secretAccessKey != "" {
+		sess, err = session.NewSession(&aws.Config{
+			Region:      aws.String(region),
+			Endpoint:    aws.String(snsEndpoint),
+			Credentials: credentials.NewStaticCredentials(accessKeyId, secretAccessKey, ""),
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	snsSvc := sns.New(sess)
+	sqsSvc := sqs.New(sess)
 
-    snsSvc := sns.New(sess)
-    sqsSvc := sqs.New(sess)
+	redisClient, err := infrastructure.NewRedisDatabase(redisAddress, redisPassword, redisDB, redisPoolSize, redisMinIdleConn)
+	if err != nil {
+		return nil, err
+	}
 
-    redisClient, err := infrastructure.NewRedisDatabase(redisAddress, redisPassword, redisDB, redisPoolSize, redisMinIdleConn)
-    if err != nil {
-        return nil, err
-    }
-
-    compressEnabled := false
-    if v := os.Getenv("PUBSUBLIB_COMPRESSION_ENABLED"); v != "" {
-        if strings.EqualFold(v, "true") || v == "1" {
-            compressEnabled = true
-        }
-    }
-    return &AWSPubSubAdapter{
-        session:         sess,
-        snsSvc:          snsSvc,
-        sqsSvc:          sqsSvc,
-        redisClient:     redisClient,
-        compressEnabled: compressEnabled,
-    }, nil
+	compressEnabled := false
+	if v := os.Getenv("PUBSUBLIB_COMPRESSION_ENABLED"); v != "" {
+		if strings.EqualFold(v, "true") || v == "1" {
+			compressEnabled = true
+		}
+	}
+	return &AWSPubSubAdapter{
+		session:         sess,
+		snsSvc:          snsSvc,
+		sqsSvc:          sqsSvc,
+		redisClient:     redisClient,
+		compressEnabled: compressEnabled,
+	}, nil
 }
 
 func (ps *AWSPubSubAdapter) SetCompressionEnabled(enabled bool) {
-    ps.compressEnabled = enabled
+	ps.compressEnabled = enabled
 }
 
 /*
@@ -76,76 +81,76 @@ When the SNS Topic is FIFO type, messageGroupId and messageDeduplicationId are r
 - messageDeduplicationId : SNS uses this to determine whether to create a new message or to use an existing one.
 */
 func (ps *AWSPubSubAdapter) Publish(topicARN string, messageGroupId, messageDeduplicationId string, message interface{}, messageAttributes map[string]interface{}) error {
-    // convert to snake_case if message is a map
-    if m, ok := message.(map[string]interface{}); ok {
-        message = helper.ConvertBodyToSnakeCase(m)
-    }
+	// convert to snake_case if message is a map
+	if m, ok := message.(map[string]interface{}); ok {
+		message = helper.ConvertBodyToSnakeCase(m)
+	}
 
-    jsonBytes, err := json.Marshal(message)
-    if err != nil {
-        return err
-    }
+	jsonBytes, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
 
-    messageBody := string(jsonBytes)
+	messageBody := string(jsonBytes)
 
-    if ps.compressEnabled {
-        if b64, err := helper.GzipAndBase64Best(jsonBytes); err == nil {
-            messageBody = b64
-            if messageAttributes == nil {
-                messageAttributes = map[string]interface{}{}
-            }
-            messageAttributes["compress"] = "true"
-        }
-    }
+	if ps.compressEnabled {
+		if b64, err := helper.GzipAndBase64Best(jsonBytes); err == nil {
+			messageBody = b64
+			if messageAttributes == nil {
+				messageAttributes = map[string]interface{}{}
+			}
+			messageAttributes["compress"] = "true"
+		}
+	}
 
-    if len(messageBody) > 200*1024 {
-        if messageAttributes == nil {
-            messageAttributes = map[string]interface{}{}
-        }
-        redisKey := uuid.New().String()
-        messageAttributes["redis_key"] = redisKey
-        if err := ps.redisClient.Set(redisKey, messageBody, 2*60); err != nil {
-            return err
-        }
-        messageBody = "body is stored in redis under key PUBSUB:" + redisKey
-    }
+	if len(messageBody) > 200*1024 {
+		if messageAttributes == nil {
+			messageAttributes = map[string]interface{}{}
+		}
+		redisKey := uuid.New().String()
+		messageAttributes["redis_key"] = redisKey
+		if err := ps.redisClient.Set(redisKey, messageBody, 2*60); err != nil {
+			return err
+		}
+		messageBody = "body is stored in redis under key PUBSUB:" + redisKey
+	}
 
-    if messageAttributes["source"] == nil {
-        return fmt.Errorf("should have source key in messageAttributes")
-    }
-    if messageAttributes["contains"] == nil {
-        return fmt.Errorf("should have contains key in messageAttributes")
-    }
-    if messageAttributes["event_type"] == nil {
-        return fmt.Errorf("should have event_type key in messageAttributes")
-    }
-    if messageAttributes["trace_id"] == nil {
-        messageAttributes["trace_id"] = uuid.New().String()
-    }
-    awsMessageAttributes := map[string]*sns.MessageAttributeValue{}
-    if messageAttributes != nil {
-        var bindErr error
-        awsMessageAttributes, bindErr = BindAttributes(messageAttributes)
-        if bindErr != nil {
-            return errors.Wrap(bindErr, "error binding attributes")
-        }
-    }
-    pubslishMessage := &sns.PublishInput{
-        Message:           aws.String(messageBody),
-        TopicArn:          aws.String(topicARN),
-        MessageAttributes: awsMessageAttributes,
-    }
-    if messageGroupId != "" {
-        pubslishMessage.MessageGroupId = aws.String(messageGroupId)
-    }
-    if messageDeduplicationId != "" {
-        pubslishMessage.MessageDeduplicationId = aws.String(messageDeduplicationId)
-    }
-    _, err = ps.snsSvc.Publish(pubslishMessage)
-    if err != nil {
-        return err
-    }
-    return nil
+	if messageAttributes["source"] == nil {
+		return fmt.Errorf("should have source key in messageAttributes")
+	}
+	if messageAttributes["contains"] == nil {
+		return fmt.Errorf("should have contains key in messageAttributes")
+	}
+	if messageAttributes["event_type"] == nil {
+		return fmt.Errorf("should have event_type key in messageAttributes")
+	}
+	if messageAttributes["trace_id"] == nil {
+		messageAttributes["trace_id"] = uuid.New().String()
+	}
+	awsMessageAttributes := map[string]*sns.MessageAttributeValue{}
+	if messageAttributes != nil {
+		var bindErr error
+		awsMessageAttributes, bindErr = BindAttributes(messageAttributes)
+		if bindErr != nil {
+			return errors.Wrap(bindErr, "error binding attributes")
+		}
+	}
+	pubslishMessage := &sns.PublishInput{
+		Message:           aws.String(messageBody),
+		TopicArn:          aws.String(topicARN),
+		MessageAttributes: awsMessageAttributes,
+	}
+	if messageGroupId != "" {
+		pubslishMessage.MessageGroupId = aws.String(messageGroupId)
+	}
+	if messageDeduplicationId != "" {
+		pubslishMessage.MessageDeduplicationId = aws.String(messageDeduplicationId)
+	}
+	_, err = ps.snsSvc.Publish(pubslishMessage)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func (ps *AWSPubSubAdapter) PollMessages(queueURL string, handler func(message *sqs.Message) error) error {
@@ -233,7 +238,7 @@ func (ps *AWSPubSubAdapter) PollMessages(queueURL string, handler func(message *
 						return derr
 					}
 				}
-			} else if compressed { 
+			} else if compressed {
 				if decoded, derr := helper.Base64DecodeAndGunzipIf(*message.Body, true); derr == nil {
 					message.Body = aws.String(string(decoded))
 				} else {


### PR DESCRIPTION
## **User description**
## Summary
- Adds comprehensive architecture documentation under `docs/architecture/` with Mermaid diagrams covering component overview, service layers, integrations, configuration, observability, and branching strategy
- Adds `CLAUDE.md` and `AGENTS.md` at repo root with directory map, layering model, coding conventions, feature-addition guides, and branching rules

## Test plan
- [ ] Review documentation accuracy against source code
- [ ] Verify all Mermaid diagrams render correctly on GitHub

Made with [Cursor](https://cursor.com)


___

## **CodeAnt-AI Description**
**Support AWS role-based access when credentials are not provided**

### What Changed
- The AWS pub/sub adapter can now start without static access keys, so services can use IAM roles for service accounts or instance profiles.
- The SNS endpoint override is now optional, which lets the adapter use the standard AWS endpoint unless a custom one is set.
- The README and architecture guides now include setup steps, configuration details, IRSA usage, and a quick start example for the library.

### Impact
`✅ Easier Kubernetes setup`
`✅ Fewer hardcoded AWS credentials`
`✅ Clearer onboarding for new services`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
